### PR TITLE
[#7] 네이버 소셜 로그인 기반 spring security & JWT 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,21 +24,22 @@ repositories {
 dependencies {
     // spring boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // validation
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    // redis
+    // redis - refresh token 사용할 때 사용
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // database

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // security
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/travelcompass/api/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/travelcompass/api/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.travelcompass.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    // 비밀번호 암호화를 위한 Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
@@ -1,0 +1,58 @@
+package com.travelcompass.api.global.config;
+
+import com.travelcompass.api.global.jwt.JwtTokenFilter;
+import com.travelcompass.api.global.oauth.OAuth2SuccessHandler;
+import com.travelcompass.api.global.oauth.OAuth2UserServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+@Configuration
+public class WebSecurityConfig {
+    private final JwtTokenFilter jwtTokenFilter;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2UserServiceImpl oAuth2UserService;
+
+    public WebSecurityConfig(
+            JwtTokenFilter jwtTokenFilter,
+            OAuth2SuccessHandler oAuth2SuccessHandler,
+            OAuth2UserServiceImpl oAuth2UserService
+    ) {
+        this.jwtTokenFilter = jwtTokenFilter;
+        this.oAuth2SuccessHandler = oAuth2SuccessHandler;
+        this.oAuth2UserService = oAuth2UserService;
+    }
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http
+    ) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authHttp -> authHttp
+                        .requestMatchers("/token/**", "/views/**").permitAll()
+                )
+                        /*.requestMatchers("/token/**", "/views/**", "/").permitAll() //누구나
+                        //.requestMatchers("/users/login").anonymous() //로그인 안된 사람만
+                        .anyRequest().authenticated() //로그인한 사람만*/
+
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .loginPage("/views/login")
+                        //handler: 인증 성공시에 사용할 handler 객체 설정
+                        //endPoint: 사용자 정보를 endPoint설정을 진행하는데, 지금은 사용자 정보 조회 후 동작을 정의하기 위해 userService를 등록하는 용도로 사용
+                        .successHandler(oAuth2SuccessHandler)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(oAuth2UserService)
+                        )
+                )
+                .sessionManagement(
+                        sessionManagement -> sessionManagement
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtTokenFilter, AuthorizationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/travelcompass/api/global/entity/CustomUserDetails.java
+++ b/src/main/java/com/travelcompass/api/global/entity/CustomUserDetails.java
@@ -1,0 +1,92 @@
+package com.travelcompass.api.global.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    @Getter
+    private Long id;
+    private String username;
+    private String password;
+    @Getter
+    private String email;
+    @Getter
+    private String provider;
+    @Getter
+    private String providerId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public static CustomUserDetails fromEntity(UserEntity entity) {
+        return CustomUserDetails.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .password(entity.getPassword())
+                .email(entity.getEmail())
+                .provider(entity.getProvider())
+                .providerId(entity.getProviderId())
+                .build();
+    }
+
+    public UserEntity newEntity() {
+        UserEntity entity = new UserEntity();
+        entity.setUsername(username);
+        entity.setPassword(password);
+        entity.setEmail(email);
+        entity.setProvider(provider);
+        entity.setProviderId(providerId);
+        return entity;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomUserDetails{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", password='[PROTECTED]'" +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/travelcompass/api/global/entity/UserEntity.java
+++ b/src/main/java/com/travelcompass/api/global/entity/UserEntity.java
@@ -1,0 +1,26 @@
+package com.travelcompass.api.global.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "users")
+@Data
+// 단순 아이디 비밀번호 외에 소셜 로그인을 통해 계정을 생성해보자.
+public class UserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // DB 제약사항 추가
+    @Column(nullable = false, unique = true)
+    private String username; //메일 id?
+    private String password; //encoding된 소셜 비밀번호
+
+    private String email;
+
+    // 소셜 로그인 제공자 문자값
+    private String provider;
+    // Naver,에서 사용자를 식별하기 위해 제공한 값
+    private String providerId;
+}

--- a/src/main/java/com/travelcompass/api/global/jwt/JwtRequestDto.java
+++ b/src/main/java/com/travelcompass/api/global/jwt/JwtRequestDto.java
@@ -1,0 +1,10 @@
+package com.travelcompass.api.global.jwt;
+
+import lombok.Data;
+
+@Data
+public class JwtRequestDto {
+    private String username;
+    private String password;
+}
+

--- a/src/main/java/com/travelcompass/api/global/jwt/JwtTokenDto.java
+++ b/src/main/java/com/travelcompass/api/global/jwt/JwtTokenDto.java
@@ -1,0 +1,8 @@
+package com.travelcompass.api.global.jwt;
+
+import lombok.Data;
+
+@Data
+public class JwtTokenDto {
+    private String token;
+}

--- a/src/main/java/com/travelcompass/api/global/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/travelcompass/api/global/jwt/JwtTokenFilter.java
@@ -1,0 +1,70 @@
+package com.travelcompass.api.global.jwt;
+
+import com.travelcompass.api.global.entity.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+// Header에 포함한 JWT를 해석하고, 그에 따라 사용자가 인증된 상태인지를 확인
+@Slf4j
+@Component
+public class JwtTokenFilter extends OncePerRequestFilter {
+    private final JwtTokenUtils jwtTokenUtils;
+
+    public JwtTokenFilter(JwtTokenUtils jwtTokenUtils) {
+        this.jwtTokenUtils = jwtTokenUtils;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        // JWT가 포함되어 있으면 포함되어 있는 헤더를 요청
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        // authHeader가 null이 아니면서 "Bearer " 로 구성되어 있어야 정상적인 인증 정보
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            // JWT를 회수하여 JWT가 정상적인 JWT인지를 판단
+            String token = authHeader.split(" ")[1];
+            if (jwtTokenUtils.validate(token)) {
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                // JWT에서 사용자 이름을 가져오기
+                String username = jwtTokenUtils
+                        .parseClaims(token)
+                        .getSubject();
+                // 사용자 인증 정보 생성
+                AbstractAuthenticationToken authenticationToken
+                        = new UsernamePasswordAuthenticationToken(
+                        CustomUserDetails.builder()
+                                .username(username)
+                                .build(),
+                        token, new ArrayList<>()
+                );
+                // SecurityContext에 사용자 정보 설정
+                context.setAuthentication(authenticationToken);
+                // SecurityContextHolder에 SecurityContext 설정
+                SecurityContextHolder.setContext(context);
+                log.info("set security context with jwt");
+            }
+            else {
+                log.warn("jwt validation failed");
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/travelcompass/api/global/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/travelcompass/api/global/jwt/JwtTokenUtils.java
@@ -1,0 +1,76 @@
+package com.travelcompass.api.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+
+@Slf4j
+@Component
+// JWT 관련 기능들을 넣어두기 위한 기능성 클래스 - 생성, 유효성 검증
+public class JwtTokenUtils {
+    private final Key signingKey;
+    private final JwtParser jwtParser;
+
+    // server의 secret key 사용 -> 보완 강화, server의 부하 감소, 서버 확장성에 대한 이점
+    public JwtTokenUtils(
+            @Value("${jwt.secret}")
+            String jwtSecret
+    ) {
+        this.signingKey
+                = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+        // JWT 번역기 만들기
+        this.jwtParser = Jwts
+                .parserBuilder()
+                .setSigningKey(this.signingKey)
+                .build();
+    }
+
+    // JWT가 유효한지 판단
+    // jjwt 라이브러리에서는 JWT를 해석하는 과정에서 유효하지 않으면 예외 발생
+    public boolean validate(String token) {
+        try {
+            // 정당한 JWT면 true,
+            jwtParser.parseClaimsJws(token); // parseClaimsJws: 암호화된 JWT를 해석하기 위한 메소드
+            return true;
+            // 정당하지 않은 JWT면 false
+        } catch (Exception e) {
+            log.warn("invalid jwt: {}", e.getClass());
+            //만료 토큰 처리 필요
+            return false;
+        }
+    }
+
+    // JWT를 인자로 받고, 그 JWT를 해석해서 사용자 정보를 회수
+    public Claims parseClaims(String token) {
+        return jwtParser
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 주어진 사용자 정보를 바탕으로 JWT를 문자열로 생성
+    public String generateToken(UserDetails userDetails) {
+        // Claims: JWT에 담기는 정보의 단위를 Claim이라 부름
+        //         Claims는 Claim들을 담기위한 Map의 상속 interface
+        Claims jwtClaims = Jwts.claims()
+                // 사용자 정보 등록
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(Date.from(Instant.now())) //생성된 시간
+                .setExpiration(Date.from(Instant.now().plusSeconds(3600))); //만료 시간
+
+        return Jwts.builder()
+                .setClaims(jwtClaims) //Claims 설정
+                .signWith(signingKey) //hmacSha로 sign
+                .compact(); //토큰 생성
+    }
+
+}
+

--- a/src/main/java/com/travelcompass/api/global/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/travelcompass/api/global/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,84 @@
+package com.travelcompass.api.global.oauth;
+
+import com.travelcompass.api.global.entity.CustomUserDetails;
+import com.travelcompass.api.global.jwt.JwtTokenUtils;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Base64;
+
+@Slf4j
+@Component
+// OAuth2 통신이 성공적으로 끝났을 때, 사용하는 클래스
+// JWT를 활용한 인증 구현하고 있기 때문에 ID Provider에게 받은 정보를 바탕으로 JWT를 발급하는 역할을 하는 용도
+// JWT를 발급하고 클라이언트가 저장할 수 있도록 특정 URL로 리다이렉트 시킴
+public class OAuth2SuccessHandler
+        // 인증 성공 후 특정 URL로 리다이렉트 시키고 싶을 때 활용할 수 있는
+        // successHandler
+        extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtTokenUtils tokenUtils;
+    private final UserDetailsManager userDetailsManager;
+
+    public OAuth2SuccessHandler(
+            JwtTokenUtils tokenUtils,
+            UserDetailsManager userDetailsManager
+    ) {
+        this.tokenUtils = tokenUtils;
+        this.userDetailsManager = userDetailsManager;
+    }
+
+    @Override
+    // 인증 성공시 호출되는 메소드
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException, ServletException {
+        // OAuth2UserServiceImpl에서 반환한 DefaultOAuth2User
+        // 가 저장된다.
+        OAuth2User oAuth2User
+                = (OAuth2User) authentication.getPrincipal();
+        // 소셜 로그인을 한 새로운 사용자를 우리의 UserEntity로 전환하기 위한 작업
+        // username: Email을 @ 기준으로 나누고,
+        //     ID Provider(Naver) 같은 값을 추가하여 조치
+        String email = oAuth2User.getAttribute("email");
+        String provider = oAuth2User.getAttribute("provider");
+        String username
+                = String.format("{%s}%s", provider, email.split("@")[0]);
+        String providerId = oAuth2User.getAttribute("id").toString();
+
+        // 처음으로 소셜 로그인한 사용자를 데이터베이스에 등록
+        if(!userDetailsManager.userExists(username)) {
+            userDetailsManager.createUser(CustomUserDetails.builder()
+                    .username(username)
+                    .password(providerId)
+                    .email(email)
+                    .provider(provider)
+                    .providerId(providerId)
+                    .build());
+        }
+
+        // 데이터베이스에서 사용자 회수
+        UserDetails details
+                = userDetailsManager.loadUserByUsername(username);
+        String jwt = tokenUtils.generateToken(details); //JWT 생성
+
+        // 목적지 URL 설정
+        // 우리 서비스의 Frontend 구성에 따라 유연하게 대처
+        String targetUrl = String.format(
+                "http://localhost:8080/token/val?token=%s", jwt
+        );
+        // 실제 Redirect 응답 생성
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/travelcompass/api/global/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/travelcompass/api/global/oauth/OAuth2UserServiceImpl.java
@@ -1,0 +1,48 @@
+package com.travelcompass.api.global.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String registrationId = userRequest
+                .getClientRegistration()
+                // application.yml에 등록한 id가 나옴
+                .getRegistrationId();
+        String nameAttribute = "";
+        // 사용할 데이터를 다시 정리하는 목적의 Map
+        Map<String, Object> attributes = new HashMap<>();
+
+        // Naver 로직
+        if (registrationId.equals("naver")) {
+            attributes.put("provider", "naver");
+            // 받은 사용자 데이터를 정리
+            Map<String, Object> responseMap = oAuth2User.getAttribute("response");
+            attributes.put("id", responseMap.get("id"));
+            attributes.put("email", responseMap.get("email"));
+            attributes.put("nickname", responseMap.get("nickname"));
+            nameAttribute = "email";
+        }
+
+        log.info(attributes.toString());
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("USER")),
+                attributes,
+                nameAttribute
+        );
+    }
+}

--- a/src/main/java/com/travelcompass/api/global/repository/UserRepository.java
+++ b/src/main/java/com/travelcompass/api/global/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.travelcompass.api.global.repository;
+
+import com.travelcompass.api.global.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    // 1. 사용자 계정이름으로 사용자 정보를 회수하는 기능
+    Optional<UserEntity> findByUsername(String username);
+    // 2. 사용자 계정이름을 가진 사용자 정보가 존재하는지 판단하는 기능
+    Boolean existsByUsername(String username);
+}

--- a/src/main/java/com/travelcompass/api/global/service/JpaUserDetailsManager.java
+++ b/src/main/java/com/travelcompass/api/global/service/JpaUserDetailsManager.java
@@ -1,0 +1,78 @@
+package com.travelcompass.api.global.service;
+
+import com.travelcompass.api.global.entity.CustomUserDetails;
+import com.travelcompass.api.global.entity.UserEntity;
+import com.travelcompass.api.global.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+// UserDetailsManager의 구현체로 만들면, Spring Security Filter에서 사용자 정보 회수에 활요할 수 있다.
+public class JpaUserDetailsManager implements UserDetailsManager {
+    private final UserRepository userRepository;
+
+
+    public JpaUserDetailsManager(
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder
+    ) {
+        this.userRepository = userRepository;
+        createUser(CustomUserDetails.builder()
+                .username("user")
+                .password(passwordEncoder.encode("asdf"))
+                .email("user@naver.com")
+                .build());
+    }
+
+    @Override
+    // UserDetailsService.loadUserByUsername(String)
+    // 실제로 Spring Security 내부에서 사용하는 반드시 구현해야 정상동작을 기대할 수 있는 메소드
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<UserEntity> optionalUser
+                = userRepository.findByUsername(username);
+        if (optionalUser.isEmpty())
+            throw new UsernameNotFoundException(username);
+        return CustomUserDetails.fromEntity(optionalUser.get());
+    }
+
+    @Override
+    // 새로운 사용자를 저장하는 메소드 (선택)
+    public void createUser(UserDetails user) {
+        log.info("try create user: {}", user.getUsername());
+        // 사용자가 (이미) 있으면 생성할 수 없다.
+        if (this.userExists(user.getUsername()))
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        try {
+            userRepository.save(
+                    ((CustomUserDetails) user).newEntity());
+        } catch (ClassCastException e) {
+            log.error("failed to cast to {}", CustomUserDetails.class);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    // 계정이름을 가진 사용자가 존재하는지 확인하는 메소드 (선택)
+    public boolean userExists(String username) {
+        log.info("check if user: {} exists", username);
+        return this.userRepository.existsByUsername(username);
+    }
+    @Override
+    public void updateUser(UserDetails user) {
+    }
+    @Override
+    public void deleteUser(String username) {
+    }
+    @Override
+    public void changePassword(String oldPassword, String newPassword) {
+    }
+}

--- a/src/main/java/com/travelcompass/api/web/controller/TokenController.java
+++ b/src/main/java/com/travelcompass/api/web/controller/TokenController.java
@@ -1,0 +1,57 @@
+package com.travelcompass.api.web.controller;
+
+import com.travelcompass.api.global.jwt.JwtRequestDto;
+import com.travelcompass.api.global.jwt.JwtTokenDto;
+import com.travelcompass.api.global.jwt.JwtTokenUtils;
+import io.jsonwebtoken.Claims;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@RestController
+@RequestMapping("token")
+public class TokenController {
+    private final UserDetailsManager manager;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenUtils jwtTokenUtils;
+
+    public TokenController(
+            UserDetailsManager manager,
+            PasswordEncoder passwordEncoder,
+            JwtTokenUtils jwtTokenUtils
+    ) {
+        this.manager = manager;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenUtils = jwtTokenUtils;
+    }
+
+    @PostMapping("/issue")
+    public JwtTokenDto issueJwt(@RequestBody JwtRequestDto dto) {
+        UserDetails userDetails
+                = manager.loadUserByUsername(dto.getUsername());
+
+        log.info(userDetails.getAuthorities().toString());
+        if (!passwordEncoder.matches(dto.getPassword(), userDetails.getPassword()))
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+
+        JwtTokenDto response = new JwtTokenDto();
+        response.setToken(jwtTokenUtils.generateToken(userDetails));
+        return response;
+    }
+
+    @GetMapping("/val")
+    public Claims val(@RequestParam("token") String jwt) {
+        return jwtTokenUtils.parseClaims(jwt);
+    }
+
+    /*@GetMapping("/val") //토큰값 화면에 띄우기
+    public String val(@RequestParam("token") String jwt){
+        return "val";
+    }   */
+}
+

--- a/src/main/java/com/travelcompass/api/web/controller/ViewController.java
+++ b/src/main/java/com/travelcompass/api/web/controller/ViewController.java
@@ -1,0 +1,15 @@
+package com.travelcompass.api.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller //-> login.html로 이동할 수 있음
+@RequestMapping("/views")
+public class ViewController {
+
+    @GetMapping("/login")
+    public String login() {
+        return "login";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,41 @@ spring:
         hbm2ddl:
           auto: create
         default_batch_fetch_size: 1000
+
+---
+
+# naver login
+spring:
+  security:
+    oauth2:
+      client:
+        # 1. 서비스 제공자에 대한 정보
+        provider:
+          # 서비스 제공자 식별자
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize #사용자를 redirect 하기 위한 URL
+            token-uri: https://nid.naver.com/oauth2.0/token #사용자 정보 요청을 위한 ACCESS TOKEN을 받기 위한 URL
+            user-info-uri: https://openapi.naver.com/v1/nid/me #사용자 정보를 조회(회수)하기 위한 URL 작성
+            user-name-attribute: response #서비스 제공자로부터 받은 사용자 정보 중 어떤 부분을 활용하는지.
+
+        # 2. 서비스 제공자를 사용하기 위한 정보
+        # 클라이언트(즉 우리 서버)를 식별하기 위한 정보
+        registration:
+          # 서비스 제공자 식별자
+          naver:
+            #서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
+            client-id: 3tVKSO15tNGbkeZJf8eE #${CLIENT_ID}
+            client-secret: zHvANLwWHH #${CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver #${REDIRECT_URL} #Call Back url
+            authorization-grant-type: authorization_code #어떤 방식으로 access token을 받을지 정의
+            client-authentication-method: client_secret_post #Client Id, Client Secret를 요청의 어디에 포함할지 정의. Body
+            client-name: Naver
+            scope:
+              - nickname
+              - email
+
+server:
+  port: 8080
+
+jwt:
+  secret: aaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesasdfqve

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+
+</head>
+<body>
+<main class="flex-shrink-0">
+  <section class="py-5">
+    <div class="container px-5">
+      <!-- log form-->
+      <div class="bg-light rounded-3 py-5 px-4 px-md-5 mb-5">
+        <div class="row gx-5 justify-content-center">
+          <div class="col-lg-8 col-xl-6">
+            <h1 class="text-center mb-5">로그인</h1>
+            <form id="sign-in-form">
+              <div class="form-floating mb-3">
+                <input class="form-control" id="identifier" name="username" type="text" placeholder="Enter your username...">
+                <label for="identifier">ID</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input class="form-control" id="password" name="password" type="password" placeholder="Enter your password...">
+                <label for="password">Password</label>
+              </div>
+              <div class="d-grid"><button class="btn btn-primary btn-lg" id="sign-in-button" type="submit">Submit</button></div>
+              <div style="margin-top: 16px; text-align: right">
+                <a href="/oauth2/authorization/naver">네이버</a>
+<!--                <a href="/views/register">회원가입</a>-->
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+<script>
+  document.getElementById("sign-in-form").addEventListener("submit", e => {
+    e.preventDefault();
+    const username = document.getElementById("identifier").value
+    const password = document.getElementById("password").value
+    fetch("/token/issue", {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ username, password })
+    }).then(response => {
+      console.log(response.status)
+      if (response.ok) response.json().then(body => {
+        location.href = "http://localhost:8080/token/val?token=" + body.token
+      })
+    })
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
### PR 타입
- 기능 추가
- 의존성, 환경 변수, 빌드 관련 코드 변경

### 반영 브랜치
feature/7 -> develop

### 변경 사항
네이버 소셜 로그인 기반 spring security & JWT 설정 

### 테스트 결과
네이버 소셜 로그인 가능하고, 생성된 토큰을 쿼리 스트링으로 던짐
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/d724057f-4676-4c7a-b9e2-4376673b7958)
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/fe7d404a-d20c-4df5-8f7a-5b9278005003)
access token 만료될 경우
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/c6215fe7-9855-481f-9f7e-1753d8034118)
필요에 따라 refresh token 추가적으로 구현 예정