### PR TITLE
[#17] 지역, 장소 관련 기본 구현

### DIFF
--- a/src/main/java/com/travelcompass/api/address/domain/Address.java
+++ b/src/main/java/com/travelcompass/api/address/domain/Address.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.adress.domain;
+package com.travelcompass.api.address.domain;
 
 import io.micrometer.common.lang.Nullable;
 import jakarta.persistence.*;

--- a/src/main/java/com/travelcompass/api/address/repository/AddressRepository.java
+++ b/src/main/java/com/travelcompass/api/address/repository/AddressRepository.java
@@ -1,7 +1,7 @@
-package com.travelcompass.api.adress.repository;
+package com.travelcompass.api.address.repository;
 
 
-import com.travelcompass.api.adress.domain.Address;
+import com.travelcompass.api.address.domain.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/travelcompass/api/address/service/AddressService.java
+++ b/src/main/java/com/travelcompass/api/address/service/AddressService.java
@@ -1,7 +1,7 @@
-package com.travelcompass.api.adress.service;
+package com.travelcompass.api.address.service;
 
-import com.travelcompass.api.adress.domain.Address;
-import com.travelcompass.api.adress.repository.AddressRepository;
+import com.travelcompass.api.address.domain.Address;
+import com.travelcompass.api.address.repository.AddressRepository;
 import com.travelcompass.api.global.api_payload.ErrorCode;
 import com.travelcompass.api.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/travelcompass/api/global/api_payload/ErrorCode.java
+++ b/src/main/java/com/travelcompass/api/global/api_payload/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode implements BaseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러, 서버 개발자에게 문의하세요."),
 
     // Address
-    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_404", "주소를 찾을 수 없습니다.")
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_404", "주소를 찾을 수 없습니다."),
+
+    // Region
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION_404", "지역을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/travelcompass/api/global/api_payload/ErrorCode.java
+++ b/src/main/java/com/travelcompass/api/global/api_payload/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode implements BaseCode {
 
     // Region
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION_404", "지역을 찾을 수 없습니다."),
+
+    // Location
+    LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "LOCATION_404", "장소를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/travelcompass/api/global/controller/RootController.java
+++ b/src/main/java/com/travelcompass/api/global/controller/RootController.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.web.controller;
+package com.travelcompass.api.global.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/travelcompass/api/global/controller/TokenController.java
+++ b/src/main/java/com/travelcompass/api/global/controller/TokenController.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.web.controller;
+package com.travelcompass.api.global.controller;
 
 import com.travelcompass.api.global.jwt.JwtRequestDto;
 import com.travelcompass.api.global.jwt.JwtTokenDto;

--- a/src/main/java/com/travelcompass/api/global/controller/ViewController.java
+++ b/src/main/java/com/travelcompass/api/global/controller/ViewController.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.web.controller;
+package com.travelcompass.api.global.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/travelcompass/api/global/entity/BaseEntity.java
+++ b/src/main/java/com/travelcompass/api/global/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.travelcompass.api.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/travelcompass/api/location/domain/Location.java
+++ b/src/main/java/com/travelcompass/api/location/domain/Location.java
@@ -1,6 +1,6 @@
 package com.travelcompass.api.location.domain;
 
-import com.travelcompass.api.adress.domain.Address;
+import com.travelcompass.api.address.domain.Address;
 import com.travelcompass.api.global.entity.BaseEntity;
 import com.travelcompass.api.region.domain.Region;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/travelcompass/api/location/domain/Location.java
+++ b/src/main/java/com/travelcompass/api/location/domain/Location.java
@@ -1,0 +1,50 @@
+package com.travelcompass.api.location.domain;
+
+import com.travelcompass.api.adress.domain.Address;
+import com.travelcompass.api.global.entity.BaseEntity;
+import com.travelcompass.api.region.domain.Region;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Location extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String tel;
+
+    @Enumerated(EnumType.STRING)
+    private LocationType locationType;
+
+    private Double latitude; // 위도
+
+    private Double longitude; // 경도
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ADDRESS_CODE")
+    private Address address;
+
+}

--- a/src/main/java/com/travelcompass/api/location/domain/LocationType.java
+++ b/src/main/java/com/travelcompass/api/location/domain/LocationType.java
@@ -1,0 +1,6 @@
+package com.travelcompass.api.location.domain;
+
+public enum LocationType {
+    RESTAURANT,  // 식당
+    ATTRACTION   // 명소
+}

--- a/src/main/java/com/travelcompass/api/location/repository/LocationRepository.java
+++ b/src/main/java/com/travelcompass/api/location/repository/LocationRepository.java
@@ -1,8 +1,10 @@
 package com.travelcompass.api.location.repository;
 
 import com.travelcompass.api.location.domain.Location;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
+    Optional<Location> findByName(String name);
 }

--- a/src/main/java/com/travelcompass/api/location/repository/LocationRepository.java
+++ b/src/main/java/com/travelcompass/api/location/repository/LocationRepository.java
@@ -1,0 +1,8 @@
+package com.travelcompass.api.location.repository;
+
+import com.travelcompass.api.location.domain.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+
+}

--- a/src/main/java/com/travelcompass/api/location/service/LocationService.java
+++ b/src/main/java/com/travelcompass/api/location/service/LocationService.java
@@ -1,0 +1,28 @@
+package com.travelcompass.api.location.service;
+
+import com.travelcompass.api.global.api_payload.ErrorCode;
+import com.travelcompass.api.global.exception.GeneralException;
+import com.travelcompass.api.location.domain.Location;
+import com.travelcompass.api.location.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LocationService {
+
+    private final LocationRepository locationRepository;
+
+    public Location findLocationById(Long id) {
+        return locationRepository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.LOCATION_NOT_FOUND));
+    }
+
+    public Location findLocationByName(String name) {
+        return locationRepository.findByName(name)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.LOCATION_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/travelcompass/api/region/domain/Region.java
+++ b/src/main/java/com/travelcompass/api/region/domain/Region.java
@@ -1,5 +1,6 @@
 package com.travelcompass.api.region.domain;
 
+import com.travelcompass.api.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @NoArgsConstructor
-public class Region {
+public class Region extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/travelcompass/api/region/domain/Region.java
+++ b/src/main/java/com/travelcompass/api/region/domain/Region.java
@@ -1,0 +1,28 @@
+package com.travelcompass.api.region.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+public class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public Region(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/travelcompass/api/region/repository/RegionRepository.java
+++ b/src/main/java/com/travelcompass/api/region/repository/RegionRepository.java
@@ -1,0 +1,8 @@
+package com.travelcompass.api.region.repository;
+
+import com.travelcompass.api.region.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+}

--- a/src/main/java/com/travelcompass/api/region/service/RegionService.java
+++ b/src/main/java/com/travelcompass/api/region/service/RegionService.java
@@ -1,0 +1,23 @@
+package com.travelcompass.api.region.service;
+
+import com.travelcompass.api.global.api_payload.ErrorCode;
+import com.travelcompass.api.global.exception.GeneralException;
+import com.travelcompass.api.region.domain.Region;
+import com.travelcompass.api.region.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RegionService {
+
+    private final RegionRepository repository;
+
+    public Region findRegionById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> GeneralException.of(ErrorCode.REGION_NOT_FOUND));
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,43 @@
-# default profile settings
 spring:
+  # default profile settings
   profiles:
     active: local
+
+  # naver login
+  security:
+    oauth2:
+      client:
+        # 1. 서비스 제공자에 대한 정보
+        provider:
+          # 서비스 제공자 식별자
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize # 사용자를 redirect 하기 위한 URL
+            token-uri: https://nid.naver.com/oauth2.0/token # 사용자 정보 요청을 위한 ACCESS TOKEN을 받기 위한 URL
+            user-info-uri: https://openapi.naver.com/v1/nid/me # 사용자 정보를 조회(회수)하기 위한 URL 작성
+            user-name-attribute: response # 서비스 제공자로부터 받은 사용자 정보 중 어떤 부분을 활용하는지.
+
+        # 2. 서비스 제공자를 사용하기 위한 정보
+        # 클라이언트(즉 우리 서버)를 식별하기 위한 정보
+        registration:
+          # 서비스 제공자 식별자
+          naver:
+            # 서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
+            client-id: 3tVKSO15tNGbkeZJf8eE # ${CLIENT_ID}
+            client-secret: zHvANLwWHH # ${CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver # ${REDIRECT_URL} #Call Back url
+            authorization-grant-type: authorization_code # 어떤 방식으로 access token을 받을지 정의
+            client-authentication-method: client_secret_post # Client Id, Client Secret를 요청의 어디에 포함할지 정의. Body
+            client-name: Naver
+            scope:
+              - nickname
+              - email
+
+server:
+  port: 8080
+
+jwt:
+  secret: aaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesasdfqve
+
 springdoc:
   swagger-ui:
     path: /swagger
@@ -28,8 +64,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-#        format_sql: true
-#        show_sql: true
+        #        format_sql: true
+        #        show_sql: true
         use_sql_comments: true
         hbm2ddl:
           auto: create
@@ -54,47 +90,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
-#        format_sql: true
-#        show_sql: true
+        #        format_sql: true
+        #        show_sql: true
         use_sql_comments: true
         hbm2ddl:
           auto: create
         default_batch_fetch_size: 1000
-
----
-
-# naver login
-spring:
-  security:
-    oauth2:
-      client:
-        # 1. 서비스 제공자에 대한 정보
-        provider:
-          # 서비스 제공자 식별자
-          naver:
-            authorization-uri: https://nid.naver.com/oauth2.0/authorize #사용자를 redirect 하기 위한 URL
-            token-uri: https://nid.naver.com/oauth2.0/token #사용자 정보 요청을 위한 ACCESS TOKEN을 받기 위한 URL
-            user-info-uri: https://openapi.naver.com/v1/nid/me #사용자 정보를 조회(회수)하기 위한 URL 작성
-            user-name-attribute: response #서비스 제공자로부터 받은 사용자 정보 중 어떤 부분을 활용하는지.
-
-        # 2. 서비스 제공자를 사용하기 위한 정보
-        # 클라이언트(즉 우리 서버)를 식별하기 위한 정보
-        registration:
-          # 서비스 제공자 식별자
-          naver:
-            #서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
-            client-id: 3tVKSO15tNGbkeZJf8eE #${CLIENT_ID}
-            client-secret: zHvANLwWHH #${CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver #${REDIRECT_URL} #Call Back url
-            authorization-grant-type: authorization_code #어떤 방식으로 access token을 받을지 정의
-            client-authentication-method: client_secret_post #Client Id, Client Secret를 요청의 어디에 포함할지 정의. Body
-            client-name: Naver
-            scope:
-              - nickname
-              - email
-
-server:
-  port: 8080
-
-jwt:
-  secret: aaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesoioegwaaaabbbsdifqbvaesasdfqve

--- a/src/test/java/com/travelcompass/api/address/AddressTest.java
+++ b/src/test/java/com/travelcompass/api/address/AddressTest.java
@@ -1,8 +1,8 @@
-package com.travelcompass.api.adress;
+package com.travelcompass.api.address;
 
-import com.travelcompass.api.adress.domain.Address;
-import com.travelcompass.api.adress.repository.AddressRepository;
-import com.travelcompass.api.adress.service.AddressService;
+import com.travelcompass.api.address.domain.Address;
+import com.travelcompass.api.address.repository.AddressRepository;
+import com.travelcompass.api.address.service.AddressService;
 import com.travelcompass.api.global.exception.GeneralException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/travelcompass/api/address/domain/AddressDomainTest.java
+++ b/src/test/java/com/travelcompass/api/address/domain/AddressDomainTest.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.adress.domain;
+package com.travelcompass.api.address.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/travelcompass/api/address/repository/AddressRepositoryTest.java
+++ b/src/test/java/com/travelcompass/api/address/repository/AddressRepositoryTest.java
@@ -1,12 +1,11 @@
-package com.travelcompass.api.adress.repository;
+package com.travelcompass.api.address.repository;
 
-import com.travelcompass.api.adress.domain.Address;
+import com.travelcompass.api.address.domain.Address;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest

--- a/src/test/java/com/travelcompass/api/address/service/AddressServiceTest.java
+++ b/src/test/java/com/travelcompass/api/address/service/AddressServiceTest.java
@@ -1,9 +1,8 @@
-package com.travelcompass.api.adress.service;
+package com.travelcompass.api.address.service;
 
-import com.travelcompass.api.adress.domain.Address;
-import com.travelcompass.api.adress.repository.AddressRepository;
+import com.travelcompass.api.address.domain.Address;
+import com.travelcompass.api.address.repository.AddressRepository;
 import com.travelcompass.api.global.exception.GeneralException;
-import org.apache.commons.lang3.ObjectUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/travelcompass/api/region/RegionIntegrationTest.java
+++ b/src/test/java/com/travelcompass/api/region/RegionIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.travelcompass.api.region;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.travelcompass.api.global.api_payload.ErrorCode;
+import com.travelcompass.api.global.exception.GeneralException;
+import com.travelcompass.api.region.domain.Region;
+import com.travelcompass.api.region.repository.RegionRepository;
+import com.travelcompass.api.region.service.RegionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class RegionIntegrationTest {
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private RegionService regionService;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        Region region1 = Region.builder().id(1L).name("서울").build();
+        regionRepository.save(region1);
+
+        Region region2 = Region.builder().id(2L).name("부산").build();
+        regionRepository.save(region2);
+    }
+
+    @Test
+    @DisplayName("지역 찾기 성공")
+    void 지역_찾기_성공() {
+        // when
+        Region region = regionService.findRegionById(1L);
+
+        // then
+        assertEquals(1L, region.getId());
+        assertEquals("서울", region.getName());
+    }
+
+    @Test
+    @DisplayName("지역 찾기 실패시 REGION_NOT_FOUND 에러 발생")
+    void 지역_찾기_실패() {
+        // when & then
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> regionService.findRegionById(3L));
+
+        assertEquals(ErrorCode.REGION_NOT_FOUND, exception.getCode());
+    }
+
+
+}

--- a/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
+++ b/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
@@ -1,0 +1,24 @@
+package com.travelcompass.api.region.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RegionTest {
+
+    @Test
+    @DisplayName("Region 객체가 생성되었는지 확인하는 테스트")
+    void createRegion() {
+        // given
+        Region region = Region.builder()
+                .id(1L)
+                .name("서울")
+                .build();
+
+        // then
+        assertEquals(1L, region.getId());
+        assertEquals("서울", region.getName());
+    }
+
+}

--- a/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
+++ b/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
@@ -9,7 +9,7 @@ class RegionTest {
 
     @Test
     @DisplayName("Region 객체가 생성되었는지 확인하는 테스트")
-    void createRegion() {
+    void region_객체_생성_확인() {
         // given
         Region region = Region.builder()
                 .id(1L)

--- a/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
+++ b/src/test/java/com/travelcompass/api/region/domain/RegionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 class RegionTest {
 
     @Test
-    @DisplayName("Region 객체가 생성되었는지 확인하는 테스트")
+    @DisplayName("Region 객체 생성 확인")
     void region_객체_생성_확인() {
         // given
         Region region = Region.builder()

--- a/src/test/java/com/travelcompass/api/region/service/RegionServiceTest.java
+++ b/src/test/java/com/travelcompass/api/region/service/RegionServiceTest.java
@@ -1,0 +1,59 @@
+package com.travelcompass.api.region.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.travelcompass.api.global.api_payload.ErrorCode;
+import com.travelcompass.api.global.exception.GeneralException;
+import com.travelcompass.api.region.domain.Region;
+import com.travelcompass.api.region.repository.RegionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegionServiceTest {
+
+    @InjectMocks
+    private RegionService regionService;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @Test
+    @DisplayName("findRegionById - Region 찾은 경우 Region 객체 반환")
+    void region_찾기_성공() {
+        // given
+        Region expectedRegion = new Region();
+        when(regionRepository.findById(anyLong())).thenReturn(Optional.of(expectedRegion));
+
+        // when
+        Region findRegion = regionService.findRegionById(1L);
+
+        // then
+        assertEquals(expectedRegion, findRegion);
+        verify(regionRepository, times(1)).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("findRegionById - Region 못 찾은 경우 GeneralException 발생")
+    void region_찾기_실패() {
+        // given
+        when(regionRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when
+        GeneralException exception = assertThrows(GeneralException.class, () -> regionService.findRegionById(1L));
+
+        // then
+        assertEquals(ErrorCode.REGION_NOT_FOUND, exception.getCode());
+        verify(regionRepository, times(1)).findById(anyLong());
+    }
+
+}

--- a/src/test/java/com/travelcompass/api/region/service/RegionServiceTest.java
+++ b/src/test/java/com/travelcompass/api/region/service/RegionServiceTest.java
@@ -43,7 +43,7 @@ class RegionServiceTest {
     }
 
     @Test
-    @DisplayName("findRegionById - Region 못 찾은 경우 GeneralException 발생")
+    @DisplayName("findRegionById - Region 못 찾은 경우 REGION_NOT_FOUND 에러 발생")
     void region_찾기_실패() {
         // given
         when(regionRepository.findById(anyLong())).thenReturn(Optional.empty());


### PR DESCRIPTION
### PR 타입
- 기능 추가

### 반영 브랜치
feature/17 -> develop

### 변경 사항
지역 엔티티, 장소 엔티티 관련해서 서비스 레이어의 findById까지만 구현했습니다.
-> repository는 기본 JPA 기능만 존재하므로 테스트하지 않았습니다.

### 테스트 결과
#### 도메인 테스트
![image](https://github.com/TravelCompass-UMC/Backend/assets/68385400/e586afeb-2aa0-464f-9caa-63333ac448b6)

#### 서비스 테스트
![image](https://github.com/TravelCompass-UMC/Backend/assets/68385400/e056cd9d-085c-49c1-a5ff-a65adbae7b14)

#### 통합 테스트
![image](https://github.com/TravelCompass-UMC/Backend/assets/68385400/70642108-be54-48c8-b7eb-ce5821b57356)