### PR TITLE
[#29] 여행그룹 테이블 리팩토링

### DIFF
--- a/src/main/java/com/travelcompass/api/plan/domain/Plan.java
+++ b/src/main/java/com/travelcompass/api/plan/domain/Plan.java
@@ -26,6 +26,8 @@ public class Plan extends BaseEntity {
 
     private LocalDate endDate;
 
+    private String inviteCode; // 초대를 위한 유니크한 코드
+
     @Enumerated(EnumType.STRING)
     private PlanVehicle vehicle;
 

--- a/src/main/java/com/travelcompass/api/plan/domain/PlanUser.java
+++ b/src/main/java/com/travelcompass/api/plan/domain/PlanUser.java
@@ -1,24 +1,21 @@
 package com.travelcompass.api.plan.domain;
 
-import com.travelcompass.api.global.entity.BaseEntity;
 import com.travelcompass.api.oauth.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+// 중간테이블
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlanGroup extends BaseEntity {
+public class PlanUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -27,6 +24,4 @@ public class PlanGroup extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
-
-    private String inviteCode; // 초대를 위한 유니크한 코드
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,10 +33,10 @@ spring:
               - email
               - profile_image
 
-  version: 1.0.4
-  redis:
-    host: ${REDIS_HOST}
-    port: ${REDIS_PORT}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/java/com/travelcompass/api/plan/domain/PlanDomainTest.java
+++ b/src/test/java/com/travelcompass/api/plan/domain/PlanDomainTest.java
@@ -58,13 +58,14 @@ public class PlanDomainTest {
 
         User user = new User();
 
-        PlanGroup planGroup = PlanGroup.builder()
-                .id(1L).name("제주팟").inviteCode("abcd").plan(plan).user(user).build();
+        PlanUser planUser = PlanUser.builder()
+                .id(1L).plan(plan).user(user).build();
+                //.id(1L).name("제주팟").plan(plan).user(user).build();
         //then
-        assertThat(planGroup.getId()).isEqualTo(1L);
-        assertThat(planGroup.getPlan()).isEqualTo(plan);
-        assertThat(planGroup.getUser()).isEqualTo(user);
-        assertThat(planGroup).isInstanceOf(PlanGroup.class);
+        assertThat(planUser.getId()).isEqualTo(1L);
+        assertThat(planUser.getPlan()).isEqualTo(plan);
+        assertThat(planUser.getUser()).isEqualTo(user);
+        assertThat(planUser).isInstanceOf(PlanUser.class);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입
- 엔티티 수정(Plan, PlanUser)
- yml 파일에서 redis 관련 내용 수정

### 반영 브랜치
refactor/29 -> develop

### 변경 사항
- planGroup 테이블 -> planUser 중간 테이블
- invite_code를 plan 테이블로 이동
- spring.data.redis.post,  spring.data.redis.host 로 경로 수정
