### PR TITLE
[#40'] 네이버 소셜 로그인 배포

### DIFF
--- a/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
@@ -1,17 +1,27 @@
 package com.travelcompass.api.global.config;
-
 import com.travelcompass.api.oauth.jwt.JwtTokenFilter;
 import com.travelcompass.api.oauth.OAuth2SuccessHandler;
 import com.travelcompass.api.oauth.OAuth2UserServiceImpl;
-import com.travelcompass.api.oauth.jwt.JwtTokenUtils;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.*;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 
 @RequiredArgsConstructor
 @Configuration
@@ -26,12 +36,13 @@ public class WebSecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authHttp -> authHttp
-                        .requestMatchers("/users/**", "/regions/**", "/locations/**", "/plans/**", "/me/**") //"/oauth/naver/**"
+                        .requestMatchers("/oauth2/authorization/naver", "/users/**", "/regions/**", "/locations/**", "/plans/**", "/me/**")
                         .permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2Login -> oauth2Login
-                        .loginPage("/users/login") //비인증 사용자를 이동시킬 로그인 페이지
+                        //.loginPage("/users/login")
+                        .loginPage("http://dev.enble.site/oauth2/authorization/naver") //비인증 사용자를 이동시킬 로그인 페이지
                         .successHandler(oAuth2SuccessHandler) //인증 성공 후 jwt 생성, 사용자 정보 db에 등록
                         //.defaultSuccessUrl("/users/main") //로그인(일정 부분) 성공하면 특정 화면으로 이동
                         .userInfoEndpoint(userInfo -> userInfo
@@ -47,3 +58,111 @@ public class WebSecurityConfig {
         return http.build();
     }
 }
+
+/*
+package com.travelcompass.api.global.config;
+import com.travelcompass.api.oauth.jwt.JwtTokenFilter;
+import com.travelcompass.api.oauth.OAuth2SuccessHandler;
+import com.travelcompass.api.oauth.OAuth2UserServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.*;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebSecurityConfig {
+    private final JwtTokenFilter jwtTokenFilter;
+    private final OAuth2UserServiceImpl oAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    @Bean
+    protected SecurityFilterChain securityFilterChain(
+            HttpSecurity http
+    ) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authHttp -> authHttp
+                        .requestMatchers("/oauth2/authorization/naver", "/users/**", "/regions/**", "/locations/**", "/plans/**", "/me/**")
+                        .permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2Login -> oauth2Login
+                        //.loginPage("/users/login")
+                        .loginPage("http://dev.enble.site/oauth2/authorization/naver") //비인증 사용자를 이동시킬 로그인 페이지
+                        .successHandler(oAuth2SuccessHandler) //인증 성공 후 jwt 생성, 사용자 정보 db에 등록
+                        //.defaultSuccessUrl("/users/main") //로그인(일정 부분) 성공하면 특정 화면으로 이동
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(oAuth2UserService) //사용자 데이터 처리
+                        )
+                )
+                .sessionManagement(
+                        sessionManagement -> sessionManagement
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(jwtTokenFilter, AuthorizationFilter.class) //UsernamePasswordAuthenticationFilter
+
+                // OAuth2 Authorization Code Grant 설정 추가
+                .oauth2Client(oauth2Client -> oauth2Client
+                        .authorizationCodeGrant(authorizationCodeGrant -> authorizationCodeGrant
+                                .authorizationRequestRepository(authorizationRequestRepository())
+                                .authorizationRequestResolver(authorizationRequestResolver())
+                                .accessTokenResponseClient(tokenResponseClient())
+                        )
+                );
+        return http.build();
+    }
+
+    // OAuth2 Authorization Code Grant에 필요한 빈을 제공
+    // 필요에 따라 커스터마이징이 필요할 수 있음
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
+    }
+    @Bean
+    public OAuth2AuthorizationRequestResolver authorizationRequestResolver() {
+        return new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository(),
+                "/oauth2/authorization"
+        );
+    }
+    @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> tokenResponseClient() {
+        return new DefaultAuthorizationCodeTokenResponseClient();
+    }
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        return new InMemoryClientRegistrationRepository(naverClientRegistration());
+    }
+
+    private ClientRegistration naverClientRegistration() {
+        return ClientRegistration.withRegistrationId("naver")
+                .clientId("3tVKSO15tNGbkeZJf8eE")
+                .clientSecret("zHvANLwWHH")
+                .redirectUri("http://dev.enble.site/login/oauth2/code/naver")
+                .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
+                .tokenUri("https://nid.naver.com/oauth2.0/token")
+                .userInfoUri("https://openapi.naver.com/v1/nid/me")
+                .userNameAttributeName("response")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE) // 수정된 부분
+                .clientName("Naver")
+                .build();
+    }
+}
+ */

--- a/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
@@ -1,4 +1,5 @@
 package com.travelcompass.api.global.config;
+
 import com.travelcompass.api.oauth.jwt.JwtTokenFilter;
 import com.travelcompass.api.oauth.OAuth2SuccessHandler;
 import com.travelcompass.api.oauth.OAuth2UserServiceImpl;
@@ -7,21 +8,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.*;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 
 @RequiredArgsConstructor
 @Configuration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
             # 서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
             client-id: 3tVKSO15tNGbkeZJf8eE #서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
             client-secret: zHvANLwWHH
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver #왜 환경변수 처리하면 안됨
+            redirect-uri: http://dev.enble.site/login/oauth2/code/naver
             authorization-grant-type: authorization_code # 어떤 방식으로 access token을 받을지 정의
             client-authentication-method: client_secret_post # Client Id, Client Secret를 요청의 어디에 포함할지 정의. Body
             client-name: Naver
@@ -67,9 +67,6 @@ springdoc:
   cache:
     disabled: true
   use-fqn: true
-
-server:
-  port: 8080
 
 ---
 


### PR DESCRIPTION
### PR 타입
- 브라우저 주소 변경

### 반영 브랜치
refactor/40 -> develop

### 변경 사항
네이버 소셜 로그인 배포 환경으로 수정

### 테스트 결과
https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=3tVKSO15tNGbkeZJf8eE&scope=nickname%20email%20profile_image&state=2sByuLo9Si0KbSG2_8jeHXLXSspYMV7N4MmdmWEvG2w%3D&redirect_uri=http://dev.enble.site/login/oauth2/code/naver
해당 주소로 접속하면 로그인 화면 뜨며
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/8662b6b7-cb82-431b-a32f-36a6fc93c1c6)
https://dev.enble.site/login/oauth2/code/naver?code=pO2ITRSXhkqTFoP41v&state=2sByuLo9Si0KbSG2_8jeHXLXSspYMV7N4MmdmWEvG2w=
해당 주소로 리다이렉트 됨

해당 code랑 state 이용해서 
https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id=3tVKSO15tNGbkeZJf8eE&client_secret=zHvANLwWHH&code=pO2ITRSXhkqTFoP41v&state=2sByuLo9Si0KbSG2_8jeHXLXSspYMV7N4MmdmWEvG2w
에 접속하면
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/9b46433e-7649-4bca-b1ed-7bf1a6b41395)
토큰 생성