### PR TITLE
[#63] 로그아웃 로직 수정 + refresh token db 저장

### DIFF
--- a/src/main/java/com/travelcompass/api/global/api_payload/SuccessCode.java
+++ b/src/main/java/com/travelcompass/api/global/api_payload/SuccessCode.java
@@ -13,9 +13,10 @@ public enum SuccessCode implements BaseCode {
 
     // User
     USER_CREATED(HttpStatus.CREATED, "USER_201", "회원가입이 완료되었습니다."),
-    USER_LOGOUT_SUCCESS(HttpStatus.OK, "USER_200", "로그아웃 되었습니다."),
-    //USER_PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "USER_200", "비밀번호가 변경되었습니다."),
-    USER_DELETE_SUCCESS(HttpStatus.OK, "USER_200", "회원탈퇴가 완료되었습니다."),
+    USER_LOGOUT_SUCCESS(HttpStatus.OK, "USER_202", "로그아웃 되었습니다."),
+    USER_REISSUE_SUCCESS(HttpStatus.OK, "USER_203", "토큰 재발급이 완료되었습니다."),
+    USER_DELETE_SUCCESS(HttpStatus.OK, "USER_204", "회원탈퇴가 완료되었습니다."),
+    //USER_PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "USER_205", "비밀번호가 변경되었습니다."),
 
     // Plan
     PLAN_CREATED(HttpStatus.CREATED, "PLAN_2011", "여행계획이 생성되었습니다."),

--- a/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/travelcompass/api/global/config/WebSecurityConfig.java
@@ -1,8 +1,9 @@
 package com.travelcompass.api.global.config;
 
-import com.travelcompass.api.oauth.jwt.JwtTokenFilter;
+import com.travelcompass.api.oauth.jwt.AuthCreationFilter;
 import com.travelcompass.api.oauth.OAuth2SuccessHandler;
 import com.travelcompass.api.oauth.OAuth2UserServiceImpl;
+import com.travelcompass.api.oauth.jwt.JwtValidationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,7 +16,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Configuration
 public class WebSecurityConfig {
-    private final JwtTokenFilter jwtTokenFilter;
+    private final AuthCreationFilter authCreationFilter;
+    private final JwtValidationFilter jwtValidationFilter;
+
     private final OAuth2UserServiceImpl oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     @Bean
@@ -33,7 +36,7 @@ public class WebSecurityConfig {
                 )
                 .oauth2Login(oauth2Login -> oauth2Login
                         //.loginPage("/users/login")
-                        //.loginPage("http://dev.enble.site/oauth2/authorization/naver") //비인증 사용자를 이동시킬 로그인 페이지
+                        //.loginPage("http://dev.enble.site:8080/oauth2/authorization/naver") //비인증 사용자를 이동시킬 로그인 페이지
                         .successHandler(oAuth2SuccessHandler) //인증 성공 후 jwt 생성, 사용자 정보 db에 등록
                         //.defaultSuccessUrl("/users/main") //로그인(일정 부분) 성공하면 특정 화면으로 이동
                         .userInfoEndpoint(userInfo -> userInfo
@@ -44,116 +47,10 @@ public class WebSecurityConfig {
                         sessionManagement -> sessionManagement
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(jwtTokenFilter, AuthorizationFilter.class); //UsernamePasswordAuthenticationFilter
+                .addFilterBefore(authCreationFilter, AuthorizationFilter.class)
+                .addFilterBefore(jwtValidationFilter, AuthCreationFilter.class)
+        ;
 
         return http.build();
     }
 }
-
-/*
-package com.travelcompass.api.global.config;
-import com.travelcompass.api.oauth.jwt.JwtTokenFilter;
-import com.travelcompass.api.oauth.OAuth2SuccessHandler;
-import com.travelcompass.api.oauth.OAuth2UserServiceImpl;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.*;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.intercept.AuthorizationFilter;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
-
-@RequiredArgsConstructor
-@Configuration
-public class WebSecurityConfig {
-    private final JwtTokenFilter jwtTokenFilter;
-    private final OAuth2UserServiceImpl oAuth2UserService;
-    private final OAuth2SuccessHandler oAuth2SuccessHandler;
-    @Bean
-    protected SecurityFilterChain securityFilterChain(
-            HttpSecurity http
-    ) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authHttp -> authHttp
-                        .requestMatchers("/oauth2/authorization/naver", "/users/**", "/regions/**", "/locations/**", "/plans/**", "/me/**")
-                        .permitAll()
-                        .anyRequest().authenticated()
-                )
-                .oauth2Login(oauth2Login -> oauth2Login
-                        //.loginPage("/users/login")
-                        .loginPage("http://dev.enble.site/oauth2/authorization/naver") //비인증 사용자를 이동시킬 로그인 페이지
-                        .successHandler(oAuth2SuccessHandler) //인증 성공 후 jwt 생성, 사용자 정보 db에 등록
-                        //.defaultSuccessUrl("/users/main") //로그인(일정 부분) 성공하면 특정 화면으로 이동
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(oAuth2UserService) //사용자 데이터 처리
-                        )
-                )
-                .sessionManagement(
-                        sessionManagement -> sessionManagement
-                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .addFilterBefore(jwtTokenFilter, AuthorizationFilter.class) //UsernamePasswordAuthenticationFilter
-
-                // OAuth2 Authorization Code Grant 설정 추가
-                .oauth2Client(oauth2Client -> oauth2Client
-                        .authorizationCodeGrant(authorizationCodeGrant -> authorizationCodeGrant
-                                .authorizationRequestRepository(authorizationRequestRepository())
-                                .authorizationRequestResolver(authorizationRequestResolver())
-                                .accessTokenResponseClient(tokenResponseClient())
-                        )
-                );
-        return http.build();
-    }
-
-    // OAuth2 Authorization Code Grant에 필요한 빈을 제공
-    // 필요에 따라 커스터마이징이 필요할 수 있음
-
-    @Bean
-    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
-        return new HttpSessionOAuth2AuthorizationRequestRepository();
-    }
-    @Bean
-    public OAuth2AuthorizationRequestResolver authorizationRequestResolver() {
-        return new DefaultOAuth2AuthorizationRequestResolver(
-                clientRegistrationRepository(),
-                "/oauth2/authorization"
-        );
-    }
-    @Bean
-    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> tokenResponseClient() {
-        return new DefaultAuthorizationCodeTokenResponseClient();
-    }
-    @Bean
-    public ClientRegistrationRepository clientRegistrationRepository() {
-        return new InMemoryClientRegistrationRepository(naverClientRegistration());
-    }
-
-    private ClientRegistration naverClientRegistration() {
-        return ClientRegistration.withRegistrationId("naver")
-                .clientId("3tVKSO15tNGbkeZJf8eE")
-                .clientSecret("zHvANLwWHH")
-                .redirectUri("http://dev.enble.site/login/oauth2/code/naver")
-                .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
-                .tokenUri("https://nid.naver.com/oauth2.0/token")
-                .userInfoUri("https://openapi.naver.com/v1/nid/me")
-                .userNameAttributeName("response")
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE) // 수정된 부분
-                .clientName("Naver")
-                .build();
-    }
-}
- */

--- a/src/main/java/com/travelcompass/api/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/travelcompass/api/oauth/OAuth2SuccessHandler.java
@@ -1,8 +1,7 @@
 package com.travelcompass.api.oauth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.travelcompass.api.oauth.jwt.*;
-//import com.travelcompass.api.oauth.repository.RefreshTokenRedisRepository;
+import com.travelcompass.api.oauth.repository.RefreshTokenRepository;
 import com.travelcompass.api.oauth.utils.IpUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.ServletException;
@@ -16,10 +15,9 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -29,15 +27,18 @@ import java.nio.charset.StandardCharsets;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtTokenUtils tokenUtils;
     private final UserDetailsManager userDetailsManager;
+    private final RefreshTokenRepository refreshTokenRepository;
 //    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     public OAuth2SuccessHandler(
             JwtTokenUtils tokenUtils,
-            UserDetailsManager userDetailsManager
+            UserDetailsManager userDetailsManager,
+            RefreshTokenRepository refreshTokenRepository
 //            RefreshTokenRedisRepository refreshTokenRedisRepository
     ) {
         this.tokenUtils = tokenUtils;
         this.userDetailsManager = userDetailsManager;
+        this.refreshTokenRepository = refreshTokenRepository;
 //        this.refreshTokenRedisRepository = refreshTokenRedisRepository;
     }
 
@@ -78,130 +79,19 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("accessToken: {}", jwt.getAccessToken());
         log.info("refreshToken: {} ", jwt.getRefreshToken());
 
-        // 유효기간 초단위 설정 후 redis에 refresh token save
-//        Claims refreshTokenClaims = tokenUtils.parseClaims(jwt.getRefreshToken());
-//        Long validPeriod
-//                = refreshTokenClaims.getExpiration().toInstant().getEpochSecond()
-//                - refreshTokenClaims.getIssuedAt().toInstant().getEpochSecond();
-//        refreshTokenRedisRepository.save(
-//                RefreshToken.builder()
-//                        .id(username)
-//                        .ip(IpUtil.getClientIp(request))
-//                        .ttl(validPeriod)
-//                        .refreshToken(jwt.getRefreshToken())
-//                        .build()
-//        );
-
-        // 목적지 URL 설정 - 토큰 던짐
-        String targetUrl = String.format(
-                "http://dev.enble.site:8080/token?access-token=%s&refresh-token=%s", jwt.getAccessToken(), jwt.getRefreshToken()
-        );
-        // 실제 Redirect 응답 생성
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
-
-        /*
-        response.sendRedirect(UriComponentsBuilder.fromUriString("http://localhost:8080/login/oauth2/code/naver")
-        //react에서 로그인 성공 후 redirect 받을 페이지
-        //login/oauth2/code/naver 페이지에 accessToken, refreshToken등의 필요한 정보를 쿼리스트링 방식으로 보냄
-                .queryParam("accessToken", "accessToken")
-                .queryParam("refreshToken", "refreshToken")
-                .build()
-                .encode(StandardCharsets.UTF_8)
-                .toUriString());
-
-
-         */
-    }
-}
-
-
-/*
-package com.travelcompass.api.oauth;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.travelcompass.api.oauth.jwt.*;
-import com.travelcompass.api.oauth.repository.RefreshTokenRedisRepository;
-import com.travelcompass.api.oauth.utils.IpUtil;
-import io.jsonwebtoken.Claims;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.provisioning.UserDetailsManager;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-
-import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-@Slf4j
-@Component
-// OAuth2 통신이 성공적으로 끝났을 때 사용됨
-// ID Provider에게 받은 정보를 바탕으로 JWT를 발급
-// + 클라이언트가 저장할 수 있도록 특정 URL로 리다이렉트
-public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    private final JwtTokenUtils tokenUtils;
-    private final UserDetailsManager userDetailsManager;
-    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
-
-    public OAuth2SuccessHandler(
-            JwtTokenUtils tokenUtils,
-            UserDetailsManager userDetailsManager,
-            RefreshTokenRedisRepository refreshTokenRedisRepository
-    ) {
-        this.tokenUtils = tokenUtils;
-        this.userDetailsManager = userDetailsManager;
-        this.refreshTokenRedisRepository = refreshTokenRedisRepository;
-    }
-
-    //@Override
-    // 인증 성공시 호출되는 메소드
-    public OAuthResponseDto onAuthenticationSuccess(
-            HttpServletRequest request,
-            //HttpServletResponse response,
-            Authentication authentication
-    ) throws IOException, ServletException {
-        // OAuth2UserServiceImpl에서 반환한 DefaultOAuth2User가 저장
-        OAuth2User oAuth2User
-                = (OAuth2User) authentication.getPrincipal();
-        // 소셜 로그인을 한 새로운 사용자를 우리의 UserEntity로 전환
-        String email = oAuth2User.getAttribute("email");
-        String nickname = oAuth2User.getAttribute("nickname");
-        String provider = oAuth2User.getAttribute("provider");
-        String username
-                = String.format("{%s}%s", provider, email.split("@")[0]);
-        String providerId = oAuth2User.getAttribute("id").toString();
-
-        // 처음으로 소셜 로그인한 사용자를 데이터베이스에 등록
-        if(!userDetailsManager.userExists(username)) { //1. 최초 로그인인지 확인
-            userDetailsManager.createUser(CustomUserDetails.builder()
-                    .username(username)
-                    .password(providerId)
-                    .email(email)
-                    .nickname(nickname)
-                    .provider(provider)
-                    .providerId(providerId)
-                    .build());
-        }
-
-        // JWT 생성 - access & refresh
-        UserDetails details
-                = userDetailsManager.loadUserByUsername(username);
-        JwtDto jwt = tokenUtils.generateToken(details); //2. access, refresh token 생성 및 발급
-        log.info("accessToken: {}", jwt.getAccessToken());
-        log.info("refreshToken: {} ", jwt.getRefreshToken());
-
-        // 유효기간 초단위 설정 후 redis에 refresh token save
+        // 유효기간 초단위 설정 후 db에 refresh token save
         Claims refreshTokenClaims = tokenUtils.parseClaims(jwt.getRefreshToken());
         Long validPeriod
                 = refreshTokenClaims.getExpiration().toInstant().getEpochSecond()
                 - refreshTokenClaims.getIssuedAt().toInstant().getEpochSecond();
-        refreshTokenRedisRepository.save(
+
+        // DB에 저장된 해당 사용자의 리프레시 토큰을 업데이트
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findById(username);
+        if (existingToken.isPresent()) {
+            refreshTokenRepository.deleteById(username);
+        }
+
+        refreshTokenRepository.save(
                 RefreshToken.builder()
                         .id(username)
                         .ip(IpUtil.getClientIp(request))
@@ -210,32 +100,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         .build()
         );
 
-        return new OAuthResponseDto(jwt.getAccessToken(), jwt.getRefreshToken());
-    }
 
-    @Override
-    // 인증 성공시 호출되는 메소드
-    public void onAuthenticationSuccess(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            Authentication authentication
-    ) throws IOException, ServletException {
-        OAuthResponseDto oAuthResponseDto = onAuthenticationSuccess(request, authentication);
-
-        // 컨트롤러로 OAuthResponseDto 반환
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(oAuthResponseDto));
-
-        response.sendRedirect(UriComponentsBuilder.fromUriString("http://localhost:8080/login/oauth2/code/naver")
-        //react에서 로그인 성공 후 redirect 받을 페이지
-        //login/oauth2/code/naver 페이지에 accessToken, refreshToken등의 필요한 정보를 쿼리스트링 방식으로 보냄
-                .queryParam("accessToken", "accessToken")
-                .queryParam("refreshToken", "refreshToken")
-                .build()
-                .encode(StandardCharsets.UTF_8)
-                .toUriString());
+        // 목적지 URL 설정 - 토큰 던짐
+        String targetUrl = String.format(
+                "http://travel-compass.netlify.app/oauth/callback?access-token=%s&refresh-token=%s", jwt.getAccessToken(), jwt.getRefreshToken()
+//                "http://localhost:8080/token?access-token=%s&refresh-token=%s", jwt.getAccessToken(), jwt.getRefreshToken()
+        );
+        // 실제 Redirect 응답 생성
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }
- */

--- a/src/main/java/com/travelcompass/api/oauth/controller/TokenController.java
+++ b/src/main/java/com/travelcompass/api/oauth/controller/TokenController.java
@@ -1,4 +1,4 @@
-package com.travelcompass.api.global.controller;
+package com.travelcompass.api.oauth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,9 +15,6 @@ public class TokenController {
             @RequestParam(name = "access-token") String accessToken,
             @RequestParam(name = "refresh-token") String refreshToken
     ) {
-        // 여기에서 accessToken, refreshToken을 사용하여 원하는 로직 수행
-        // 예를 들어, 사용자 정보 조회 등의 비즈니스 로직을 수행할 수 있습니다.
-
         // 결과 데이터를 Map에 담아 반환
         Map<String, String> responseData = new HashMap<>();
         responseData.put("accessToken", accessToken);

--- a/src/main/java/com/travelcompass/api/oauth/controller/UserController.java
+++ b/src/main/java/com/travelcompass/api/oauth/controller/UserController.java
@@ -1,7 +1,8 @@
-package com.travelcompass.api.global.controller;
+package com.travelcompass.api.oauth.controller;
 
 import com.travelcompass.api.global.api_payload.ApiResponse;
 import com.travelcompass.api.global.api_payload.SuccessCode;
+import com.travelcompass.api.oauth.jwt.JwtDto;
 import com.travelcompass.api.oauth.jwt.JwtTokenUtils;
 import com.travelcompass.api.oauth.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,26 +24,19 @@ public class UserController {
         return ApiResponse.onSuccess(SuccessCode.USER_LOGOUT_SUCCESS, 1);
     }
 
+    // 토큰 재발급
+    @PostMapping("/reissue")
+    public ApiResponse<JwtDto> reissue(
+            HttpServletRequest request
+    ) {
+        JwtDto jwt = userService.reissue(request);
+        return ApiResponse.onSuccess(SuccessCode.USER_REISSUE_SUCCESS, jwt);
+    }
+
     // 회원탈퇴
     @DeleteMapping("/me")
     public ApiResponse<Integer> deleteUser(Authentication auth) {
         userService.deleteUser(auth.getName());
         return ApiResponse.onSuccess(SuccessCode.USER_DELETE_SUCCESS, 1);
     }
-/*
-    // 토큰 재발급
-    @PostMapping("/reissue")
-    public ApiResponse<UserResponseDto.ReissueDto> reissue(
-            HttpServletRequest request
-    ) {
-        JwtDto jwt = userService.reissue(request);
-        return ApiResponse.onSuccess(UserConverter.toLogoutDto(jwt));
-    }
-    // 임시 페이지
-    @GetMapping("/kak")
-    public String kak() {
-        return "kak";
-    }
-*/
-
 }

--- a/src/main/java/com/travelcompass/api/oauth/jwt/AuthCreationFilter.java
+++ b/src/main/java/com/travelcompass/api/oauth/jwt/AuthCreationFilter.java
@@ -1,30 +1,30 @@
 package com.travelcompass.api.oauth.jwt;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 // Header에 포함한 JWT를 해석하고, 그에 따라 사용자가 인증된 상태인지를 확인
 @Slf4j
 @Component
-public class JwtTokenFilter extends OncePerRequestFilter {
+@RequiredArgsConstructor
+public class AuthCreationFilter extends OncePerRequestFilter {
     private final JwtTokenUtils jwtTokenUtils;
-
-    public JwtTokenFilter(JwtTokenUtils jwtTokenUtils) {
-        this.jwtTokenUtils = jwtTokenUtils;
-    }
 
     @Override
     protected void doFilterInternal(
@@ -32,38 +32,44 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+        log.info("url : {}", request.getServletPath());
+
         // JWT가 포함되어 있으면 포함되어 있는 헤더를 요청
         String authHeader
                 = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("authHeader 확인: " + authHeader);
+
         // authHeader가 null이 아니면서 "Bearer " 로 구성되어 있어야 정상적인 인증 정보
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             // JWT를 회수하여 JWT가 정상적인 JWT인지를 판단
             String token = authHeader.split(" ")[1];
-            if (jwtTokenUtils.validate(token)) {
-                // Security 공식 문서
-                SecurityContext context
-                        = SecurityContextHolder.createEmptyContext();
-                // JWT에서 사용자 이름을 가져오기
-                String username = jwtTokenUtils
-                        .parseClaims(token)
-                        .getSubject();
-                // 사용자 인증 정보 생성
-                AbstractAuthenticationToken authenticationToken
-                        = new UsernamePasswordAuthenticationToken(
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            Authentication authentication;
+
+            if (request.getServletPath().equals("/users/reissue")) {
+                log.info("엑세스 토큰 재발급을 위한 익명 인증 객체 생성");
+                authentication =
+                        new AnonymousAuthenticationToken( //객체 새로 만들어서 필터로 보내줌
+                                "key",
+                                "anonymousUser",
+                                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+                        );
+
+            } else {
+                log.info("사용자 인증 객체 생성 시작");
+                Claims claims = jwtTokenUtils.parseClaims(token);
+                authentication = new UsernamePasswordAuthenticationToken(
                         CustomUserDetails.builder()
-                                .username(username)
+                                .username(claims.getSubject())
                                 .build(),
-                        token, new ArrayList<>()
+                        token,
+                        jwtTokenUtils.getAuthFromClaims(claims)
                 );
-                // SecurityContext에 사용자 정보 설정
-                context.setAuthentication(authenticationToken);
-                // SecurityContextHolder에 SecurityContext 설정
-                SecurityContextHolder.setContext(context);
-                log.info("set security context with jwt");
             }
-            else {
-                log.warn("jwt validation failed");
-            }
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+            log.info("{} 인증 객체 생성 완료", context.getAuthentication().getName());
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/travelcompass/api/oauth/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/travelcompass/api/oauth/jwt/JwtTokenUtils.java
@@ -7,11 +7,14 @@ import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
-import java.sql.Date;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
 import java.time.Instant;
 import java.util.stream.Collectors;
 
@@ -90,5 +93,15 @@ public class JwtTokenUtils {
         return jwtParser
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    // 문자열로 저장된 authorities를 다시 Collection으로 변환 - 반영x
+    public Collection<? extends GrantedAuthority> getAuthFromClaims(Claims claims){
+
+        String authoritiesString = (String) claims.get("authorities"); // authorities 정보 가져오기
+
+        return Arrays.stream(authoritiesString.split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/travelcompass/api/oauth/jwt/JwtValidationFilter.java
+++ b/src/main/java/com/travelcompass/api/oauth/jwt/JwtValidationFilter.java
@@ -1,0 +1,75 @@
+package com.travelcompass.api.oauth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.travelcompass.api.global.api_payload.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+//JWT가 유효한지 판단
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtValidationFilter extends OncePerRequestFilter {
+    private final JwtTokenUtils jwtTokenUtils;
+    private final ObjectMapper objectMapper;
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("authHeader 확인: " + authHeader);
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.split(" ")[1];
+
+            log.info("token 검증 시작: {}", token);
+            try {
+                jwtTokenUtils.parseClaims(token);
+            } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+                log.info("JWT 서명이 잘못되었습니다.");
+                jwtExceptionHandler(response, ErrorCode.TOKEN_INVALID);
+//                throw new GeneralException(ErrorCode.TOKEN_INVALID);
+            } catch (ExpiredJwtException e) {
+                log.info("JWT 토큰이 만료되었습니다.");
+                jwtExceptionHandler(response, ErrorCode.TOKEN_EXPIRED);
+//                throw new GeneralException(ErrorCode.TOKEN_EXPIRED);
+            } catch (UnsupportedJwtException e) {
+                log.info("지원되지 않는 토큰입니다.");
+                jwtExceptionHandler(response, ErrorCode.TOKEN_INVALID);
+//                throw new GeneralException(ErrorCode.TOKEN_INVALID);
+            } catch (IllegalArgumentException e) {
+                log.info("잘못된 토큰입니다.");
+                jwtExceptionHandler(response, ErrorCode.TOKEN_INVALID);
+//                throw new GeneralException(ErrorCode.TOKEN_INVALID);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    public void jwtExceptionHandler(HttpServletResponse response, ErrorCode error) {
+        response.setStatus(error.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        log.info("필터 에러 커스텀");
+        try {
+            objectMapper.writeValue(response.getWriter(), error.getReason());
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/travelcompass/api/oauth/jwt/RefreshToken.java
+++ b/src/main/java/com/travelcompass/api/oauth/jwt/RefreshToken.java
@@ -1,40 +1,37 @@
-//package com.travelcompass.api.oauth.jwt;
-//
-//import lombok.AllArgsConstructor;
-//import lombok.Builder;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//import org.springframework.data.annotation.Id;
-//import org.springframework.data.redis.core.RedisHash;
-//import org.springframework.data.redis.core.TimeToLive;
-//import org.springframework.data.redis.core.index.Indexed;
-//import org.springframework.security.core.GrantedAuthority;
-//
-//import java.util.Collection;
-//@Builder
-//@Getter
-//@AllArgsConstructor
-//@NoArgsConstructor
-//@RedisHash(value = "refresh",  timeToLive = 1000L)
-//public class RefreshToken {
-//
-//    @Id
-//    private String id;
-//
-//    private String ip;
-//
+package com.travelcompass.api.oauth.jwt;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collection;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    private String id;
+
+    private String ip;
+
+    @ElementCollection
+    private Collection<String> authorities; // 권한을 문자열 형태로 저장
 //    private Collection<? extends GrantedAuthority> authorities;
-//
-//    @Indexed
-//    private String refreshToken;
-//
-//    @TimeToLive
-//    private Long ttl;
-//
-//    public void updateRefreshToken(String refreshToken) {
-//        this.refreshToken = refreshToken;
-//    }
-//    public void updateTtl(Long ttl) {
-//        this.ttl = ttl;
-//    }
-//}
+
+    private String refreshToken;
+
+    private Long ttl;
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/travelcompass/api/oauth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/travelcompass/api/oauth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.travelcompass.api.oauth.repository;
+
+import com.travelcompass.api.oauth.jwt.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken); //reissue
+    boolean existsById(String username);
+    void deleteById(String username);
+}

--- a/src/main/java/com/travelcompass/api/oauth/service/UserService.java
+++ b/src/main/java/com/travelcompass/api/oauth/service/UserService.java
@@ -3,13 +3,16 @@ package com.travelcompass.api.oauth.service;
 import com.travelcompass.api.global.api_payload.ErrorCode;
 import com.travelcompass.api.global.exception.GeneralException;
 import com.travelcompass.api.oauth.domain.User;
-//import com.travelcompass.api.oauth.jwt.JwtTokenUtils;
+import com.travelcompass.api.oauth.jwt.JwtDto;
 import com.travelcompass.api.oauth.jwt.JwtTokenUtils;
-//import com.travelcompass.api.oauth.repository.RefreshTokenRedisRepository;
+import com.travelcompass.api.oauth.jwt.RefreshToken;
+import com.travelcompass.api.oauth.repository.RefreshTokenRepository;
 import com.travelcompass.api.oauth.repository.UserRepository;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 //    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     private final PasswordEncoder passwordEncoder;
@@ -28,63 +32,71 @@ public class UserService {
 
     // 로그아웃
     public void logout(HttpServletRequest request) {
-        // 1. 레디스에 해당 토큰 있는 지 확인
+        // 1. access token 찾아오기
         String accessToken = request.getHeader("Authorization").split(" ")[1];
 
         // 2. 리프레시 토큰을 username으로 찾아 삭제
         String username = jwtTokenUtils.parseClaims(accessToken).getSubject();
         log.info("access token에서 추출한 username : {}", username);
-//        if (refreshTokenRedisRepository.existsById(username)) {
-//            refreshTokenRedisRepository.deleteById(username);
-//            log.info("레디스에서 리프레시 토큰 삭제 완료");
-//        } else {
-//            throw GeneralException.of(ErrorCode.WRONG_REFRESH_TOKEN);
-//        }
+        if (refreshTokenRepository.existsById(username)) {
+            refreshTokenRepository.deleteById(username);
+            log.info("DB에서 리프레시 토큰 삭제 완료");
+        } else {
+            throw GeneralException.of(ErrorCode.WRONG_REFRESH_TOKEN);
+        }
     }
+
+    // access, refresh 토큰 재발급
+    public JwtDto reissue(HttpServletRequest request ) {
+        // 1. Request에서 Refresh Token 추출
+        String refreshTokenValue = request.getHeader("Authorization").split(" ")[1];
+
+        // 2. DB에서 해당 Refresh Token을 찾음
+        RefreshToken refreshToken = refreshTokenRepository.findByRefreshToken(refreshTokenValue)
+                .orElseThrow(() -> new GeneralException(ErrorCode.WRONG_REFRESH_TOKEN));
+        log.info("찾은 refresh token : {}", refreshToken);
+
+        // 3. Refresh Token의 유효기간 확인 (생략)
+
+        // 4. Refresh Token을 발급한 사용자 정보 로드
+        UserDetails userDetails = manager.loadUserByUsername(refreshToken.getId());
+        log.info("refresh token에서 추출한 username : {}", refreshToken.getId());
+
+        // 5. 새로운 Access Token 및 Refresh Token 생성
+        JwtDto jwt = jwtTokenUtils.generateToken(userDetails);
+        log.info("reissue: refresh token 재발급 완료");
+
+        // 6. Refresh Token 정보 업데이트 및 DB에 저장
+        refreshToken.updateRefreshToken(jwt.getRefreshToken());
+        Claims refreshTokenClaims = jwtTokenUtils.parseClaims(jwt.getRefreshToken());
+        Long validPeriod = refreshTokenClaims.getExpiration().toInstant().getEpochSecond()
+                - refreshTokenClaims.getIssuedAt().toInstant().getEpochSecond();
+        refreshToken.updateTtl(validPeriod);
+        refreshTokenRepository.save(refreshToken);
+        log.info("accessToken: {}", jwt.getAccessToken());
+        log.info("refreshToken: {} ", jwt.getRefreshToken());
+
+        // 7. DB에 새로운 리프레시 토큰이 정상적으로 저장되었는지 확인
+        if (!refreshTokenRepository.existsById(refreshToken.getId())) {
+            throw GeneralException.of(ErrorCode.WRONG_REFRESH_TOKEN);
+        }
+
+        return jwt;
+    }
+
     // 회원 탈퇴
     public void deleteUser(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
-//        if (refreshTokenRedisRepository.existsById(username)) {
-//            refreshTokenRedisRepository.deleteById(username);
-//            log.info("레디스에서 리프레시 토큰 삭제 완료");
-//        }
+        if (refreshTokenRepository.existsById(username)) {
+            refreshTokenRepository.deleteById(username);
+            log.info("DB에서 리프레시 토큰 삭제 완료");
+        }
         userRepository.delete(user);
         log.info("{} 회원 탈퇴 완료", username);
     }
 
-    /*
-    // access, refresh 토큰 재발급
-    public JwtDto reissue(HttpServletRequest request ) {
-        // 1. 레디스에 해당 토큰 있는 지 확인
-        RefreshToken refreshToken = refreshTokenRedisRepository
-                .findByRefreshToken(request.getHeader("Authorization").split(" ")[1])
-                .orElseThrow(() -> new GeneralException(ErrorCode.WRONG_REFRESH_TOKEN));
-
-        // 2. 리프레시 토큰을 발급한 IP와 동일한 IP에서 온 요청인지 확인 (생략가능)
-        if (!IpUtil.getClientIp(request).equals(refreshToken.getIp())) {
-            throw new GeneralException(ErrorCode.IP_NOT_MATCHED);
-        }
-
-        // 3. 리프레시 토큰에서 username 찾기
-        String username = refreshToken.getId();
-        log.info("refresh token에서 추출한 username : {}", username);
-        // 4. userdetails 불러오기
-        UserDetails userDetails = manager.loadUserByUsername(username);
-
-        log.info("reissue: refresh token 재발급 완료");
-        JwtDto jwtDto = jwtTokenUtils.generateToken(userDetails);
-        refreshToken.updateRefreshToken(jwtDto.getRefreshToken());
-        // 유효기간 초단위 설정 후 redis에 timeToLive 설정
-        Claims refreshTokenClaims = jwtTokenUtils.parseClaims(jwtDto.getRefreshToken());
-        Long validPeriod
-                = refreshTokenClaims.getExpiration().toInstant().getEpochSecond()
-                - refreshTokenClaims.getIssuedAt().toInstant().getEpochSecond();
-        refreshToken.updateTtl(validPeriod);
-        refreshTokenRedisRepository.save(refreshToken);
-        return jwtDto;
-    }
-*/
+    // username으로 User찾기
     public User findUserByUserName(String userName){
         return userRepository.findByUsername(userName)
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
             client-id: 3tVKSO15tNGbkeZJf8eE #서비스 제공자측에 저희가 어떤 서비스인지 인증하기 위한 값
             client-secret: zHvANLwWHH
             redirect-uri: http://dev.enble.site:8080/login/oauth2/code/naver
+            #redirect-uri: http://localhost:8080/login/oauth2/code/naver
             authorization-grant-type: authorization_code # 어떤 방식으로 access token을 받을지 정의
             client-authentication-method: client_secret_post # Client Id, Client Secret를 요청의 어디에 포함할지 정의. Body
             client-name: Naver
@@ -32,10 +33,10 @@ spring:
               - nickname
               - email
 
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+#  data:
+#    redis:
+#      host: ${REDIS_HOST}
+#      port: ${REDIS_PORT}
 
 kakao:
   local:


### PR DESCRIPTION
### PR 타입
- 기능 수정 (로직 추가 & 수정)

### 반영 브랜치
refactor/63  -> develop

### 변경 사항
- 로그인 시 발급받은 refresh token db(refresh_token)에 저장

- 만료된 access token 사용시 토큰 만료되었다는 응답 반환
- /reissue로 토큰 발급 요청 받으면(헤더로 리프레시 토큰 받음) access token + refresh token 모두 재발급
     -> db의 refresh token update & response body로 access token, refresh token 응답


### 테스트 결과
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/9020ea68-0d7a-4fa5-ac3e-3665a0a414a8)
로그인 시 발급받은 refresh token db(refresh_token)에 저장

![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/634a7fd2-68ff-4a85-b759-db3ceb3b7739)
만료된 access token 사용시 토큰 만료되었다는 응답 반환

![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/f1f80d8b-1109-4669-beac-1bd6842664c9)
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/39f9a3b3-6b8c-4ba2-83ed-e20e727067b6)
토큰 재발급 완료
![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/b3ba6afa-0689-4308-be38-b205298022a7)
재발급된 refresh token  db에 저장

![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/ffb584b9-2bbc-4a2b-abc9-01c2d9e0203e)
새로 발급받은 access token 사용 가능 예시

![image](https://github.com/TravelCompass-UMC/Backend/assets/121751509/4ddafe45-9190-4bc3-a457-70c02df31299)
리다이렉트 url 수정(프론트 도메인으로 토큰 쏴주기)